### PR TITLE
feat: 플래너 부분 UserId Firebase 인증 연동 및 UI 개선

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.jeju.evtravel"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,9 +33,16 @@
             android:exported="true"
             android:label="EVTravel"
             android:theme="@style/Theme.EVTravel">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth"/>
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/CalendarScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/CalendarScreen.kt
@@ -201,7 +201,7 @@ fun CalendarScreen(
                     .height(60.dp),
                 enabled = true,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF1B6BF3),
+                    containerColor = Color(0xFF0173FF),
                     disabledContainerColor = Color(0xFFE5E5E5)
                 ),
                 shape = RoundedCornerShape(size = 10.dp)

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
@@ -439,24 +439,22 @@ fun EditPlanScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(59.dp)
-                        .shadow(
-                            elevation = 4.dp,
-                            shape = RoundedCornerShape(10.dp),
-                            ambientColor = Color(0x40A7A7A7),
-                            spotColor = Color(0x40A7A7A7)
-                        )
                         .background(
-                            color = Color.White,
+                            color = Color(0xFFE9E9E9),
                             shape = RoundedCornerShape(size = 10.dp)
                         )
                         .clickable { onAddDestinationClick() },
                     contentAlignment = Alignment.Center
                 ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_add_plan_spot),
-                        contentDescription = "여행지 추가",
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize() // Box에 맞춰 아이콘 크기를 조정
+                    Text(
+                        text = " + 여행지 추가하기",
+                        style = TextStyle(
+                            fontSize = 15.sp,
+                            lineHeight = 24.sp,
+                            fontFamily = FontFamily(Font(R.font.roboto)),
+                            fontWeight = FontWeight(700),
+                            color = Color(0xFF9D9D9D),
+                        )
                     )
                 }
                 
@@ -468,7 +466,7 @@ fun EditPlanScreen(
                         .fillMaxWidth()
                         .height(59.dp)
                         .background(
-                            color = Color(0xFF007BFF),
+                            color = Color(0xFF0173FF),
                             shape = RoundedCornerShape(size = 10.dp)
                         )
                         .clickable {
@@ -492,11 +490,16 @@ fun EditPlanScreen(
                         },
                     contentAlignment = Alignment.Center
                 ) {
-                    Image(
-                        painter = painterResource(id = R.drawable.ic_planner_next),
-                        contentDescription = "다음",
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier.fillMaxSize() // Box에 맞춰 아이콘 크기를 조정
+                    Text(
+                        text = "다음",
+                        style = TextStyle(
+                            fontSize = 17.sp,
+                            lineHeight = 24.sp,
+                            fontFamily = FontFamily(Font(R.font.roboto)),
+                            fontWeight = FontWeight(600),
+                            color = Color(0xFFFFFFFF),
+                            letterSpacing = 0.21.sp,
+                        )
                     )
                 }
             }

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
@@ -92,10 +92,6 @@ fun PlanListScreen(
         }
     }
     
-    LaunchedEffect(Unit) {
-        viewModel.loadPlans("somi") // 실제 사용자 ID로 변경 필요
-    }
-    
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
@@ -2,20 +2,20 @@ package com.jeju.evtravel.ui.planner
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jeju.evtravel.BuildConfig
 import com.jeju.evtravel.data.model.DayPlan
-import com.jeju.evtravel.data.model.PlanDto
 import com.jeju.evtravel.data.model.PlaceDto
+import com.jeju.evtravel.data.model.PlanDto
+import com.jeju.evtravel.data.remote.RetrofitInstance
+import com.jeju.evtravel.data.repository.ChargerRepositoryImpl
+import com.jeju.evtravel.data.repository.PlaceRepositoryImpl
 import com.jeju.evtravel.data.repository.PlanRepositoryImpl
 import com.jeju.evtravel.domain.usecase.SavePlanUseCase
+import com.jeju.evtravel.domain.usecase.SearchPlaceUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import com.jeju.evtravel.domain.usecase.SearchPlaceUseCase
-import com.jeju.evtravel.data.repository.PlaceRepositoryImpl
-import com.jeju.evtravel.data.remote.RetrofitInstance
-import com.jeju.evtravel.BuildConfig
-import com.jeju.evtravel.data.repository.ChargerRepositoryImpl
 
 /**
  * PlannerViewModel은 여행 계획을 관리하는 ViewModel입니다.
@@ -25,6 +25,9 @@ class PlannerViewModel : ViewModel() {
     // 의존성 주입 (실제 앱에서는 Hilt 등을 사용하여 주입)
     private val repository = PlanRepositoryImpl()
     private val savePlanUseCase = SavePlanUseCase(repository)
+    
+    // 현재 로그인된 사용자의 ID를 저장할 변수
+    private var currentUserId: String? = null
     
     // 날짜별 DayPlan 상태
     private val _dayPlans = MutableStateFlow<List<DayPlan>>(emptyList())
@@ -101,20 +104,23 @@ class PlannerViewModel : ViewModel() {
         start: String,
         end: String,
         onSaveComplete: () -> Unit
-    ) { // onSaveComplete 콜백 추가
+    ) {
+        // 저장된 userId를 사용, 없으면 함수 종료
+        val userId = currentUserId ?: return
+        
         viewModelScope.launch {
             val plan = PlanDto(
                 startDate = start,
                 endDate = end,
                 days = _dayPlans.value,  // 날짜별 DayPlan 객체들 그대로 저장
-                userId = "somi"      // 실제 로그인 사용자 ID로 대체
+                userId = userId
             )
             
             savePlanUseCase(plan,
                 onSuccess = {
                     // 저장이 성공하면, 플랜 목록을 다시 불러옵니다.
                     viewModelScope.launch {
-                        _plans.value = repository.getPlans("somi")
+                        _plans.value = repository.getPlans(userId)
                         // 목록 로드까지 완료되면, 파라미터로 받은 콜백(화면 전환)을 실행
                         onSaveComplete()
                     }
@@ -192,6 +198,8 @@ class PlannerViewModel : ViewModel() {
      * @param userId 사용자 ID
      */
     fun loadPlans(userId: String) {
+        // ViewModel에 현재 사용자 ID 저장
+        this.currentUserId = userId
         viewModelScope.launch {
             _plans.value = repository.getPlans(userId)
         }
@@ -202,10 +210,12 @@ class PlannerViewModel : ViewModel() {
      * @param planId 삭제할 플랜의 ID
      */
     fun deletePlan(planId: String) {
+        // 저장된 userId를 사용, 없으면 함수 종료
+        val userId = currentUserId ?: return
         viewModelScope.launch {
             try {
                 repository.deletePlan(planId)
-                loadPlans("somi") // 삭제 후 플랜 목록 갱신
+                loadPlans(userId) // 삭제 후 플랜 목록 갱신
             } catch (e: Exception) {
                 println("플랜 삭제 중 오류 발생: ${e.message}")
             }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  문서 수정
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/planner` → `develop`

### 변경 사항

**1. 플래너 기능에 Firebase 인증 시스템 연동**

- `PlannerViewModel`이 현재 로그인된 사용자의 ID(`currentUserId`)를 저장하고 관리하도록 로직을 추가했습니다.
- 기존에 `"somi"`로 하드코딩되었던 부분을 제거하고, 플랜 저장, 조회, 삭제 시 동적으로 인증된 사용자 ID를 사용하도록 리팩토링했습니다.
- 이를 통해 게스트 로그인을 포함한 모든 사용자가 개인화된 플랜을 생성하고 관리할 수 있습니다.

**2. `EditPlanScreen` UI/UX 개선**

- 기존 아이콘 버튼들을 명확한 텍스트 버튼으로 변경했습니다.

### 테스트 결과
- **인증 연동 테스트**
    - 게스트로 로그인하여 새로운 플랜을 생성, 저장, 삭제하는 기능이 정상적으로 동작하는 것을 확인했습니다.
- **UI 테스트**
    - `EditPlanScreen` 진입 시, '다음' 버튼과 '+ 여행지 추가하기' 버튼이 새로운 텍스트와 스타일로 정상적으로 표시되는 것을 확인했습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 스타일
  - ‘여행지 추가하기’ 버튼을 아이콘에서 텍스트 버튼으로 변경하고 배경 및 타이포그래피를 개선했습니다.
  - ‘다음’ 버튼의 색상과 텍스트 스타일을 일관되게 조정했습니다.
  - 캘린더 화면의 ‘다음’ 버튼 색상을 조정했습니다.

- 버그 수정
  - ‘다음’ 선택 시 저장이 완료된 후에만 다음 단계로 이동하도록 변경해 데이터 유실을 방지합니다.
  - 일정 저장/조회/삭제가 현재 로그인한 사용자 기준으로 정확히 동작하도록 수정했습니다.
  - 특정 사용자로 자동 로드되던 동작을 제거했습니다.

- 기타
  - 앱 버전이 1.0.1(버전코드 2)로 업데이트되었습니다.
  - 앱에서 외부 딥링크(특정 스킴)를 처리하도록 지원을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->