### PR TITLE
fix: 플래너 업데이트 기능 버그 수정

### DIFF
--- a/app/src/main/java/com/jeju/evtravel/MainActivity.kt
+++ b/app/src/main/java/com/jeju/evtravel/MainActivity.kt
@@ -1,4 +1,3 @@
-// com/jeju/evtravel/MainActivity.kt
 package com.jeju.evtravel
 
 import android.os.Bundle
@@ -13,7 +12,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,7 +22,6 @@ import androidx.navigation.navArgument
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.firebase.auth.FirebaseAuth
-import com.jeju.evtravel.data.service.GuestLoginService
 import com.jeju.evtravel.navigation.BottomNavigationBar
 import com.jeju.evtravel.ui.map.KakaoMapScreen
 import com.jeju.evtravel.ui.map.MapViewModel
@@ -218,6 +215,8 @@ fun MainScreen(
                 composable("planner_initial") {
                     PlannerScreen(
                         onCreatePlanClick = {
+                            // 새 플랜 생성을 위해 ViewModel 상태 초기화
+                            plannerViewModel.clearPlanDetails()
                             navController.navigate("calendar")
                         }
                     )
@@ -248,7 +247,11 @@ fun MainScreen(
                         selectedStart = start, // 추출한 값을 PlanListScreen에 전달
                         selectedEnd = end,     // 추출한 값을 PlanListScreen에 전달
                         onBackClick = { /* 추후 수정 */ },
-                        onCreatePlanClick = { navController.navigate("calendar") },
+                        onCreatePlanClick = {
+                            // 새 플랜 생성을 위해 ViewModel 상태 초기화
+                            plannerViewModel.clearPlanDetails()
+                            navController.navigate("calendar")
+                        },
                         onPlanClick = { plan ->
                             navController.navigate("editPlan/${plan.id}")
                         }

--- a/app/src/main/java/com/jeju/evtravel/data/remote/firebase/PlanRemoteDataSource.kt
+++ b/app/src/main/java/com/jeju/evtravel/data/remote/firebase/PlanRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.jeju.evtravel.data.remote.firebase
 
+import android.util.Log
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.jeju.evtravel.data.model.PlanDto
@@ -20,6 +21,8 @@ class PlanRemoteDataSource(
      * @param onSuccess 저장 성공 시 실행될 콜백 함수
      * @param onFailure 저장 실패 시 실행될 콜백 함수 (예외 전달)
      */
+    private val TAG = "PlannerDebug"
+    
     fun savePlan(plan: PlanDto, onSuccess: () -> Unit = {}, onFailure: (Exception) -> Unit = {}) {
         // 현재 시간으로 생성/수정 시간을 설정한 새로운 플랜 객체 생성
         val planWithTimestamps = plan.copy(
@@ -58,15 +61,23 @@ class PlanRemoteDataSource(
      * @param plan 업데이트할 플랜 데이터
      */
     suspend fun updatePlan(plan: PlanDto) {
-        val planId = plan.id.ifEmpty { throw IllegalArgumentException("업데이트할 Plan의 ID가 없습니다.") }
-        
+        val planId = plan.id.ifEmpty {
+            Log.e(TAG, "PlanRemoteDataSource: Update failed because Plan ID is empty.")
+            throw IllegalArgumentException("업데이트할 Plan의 ID가 없습니다.")
+        }
         // 수정 시간을 현재 시간으로 설정
+        Log.d(TAG, "PlanRemoteDataSource: Attempting to update planId '$planId' in Firestore.")
         val planWithTimestamp = plan.copy(updatedAt = Timestamp.now())
         
-        // Firestore의 'plans' 컬렉션에서 해당 ID의 문서를 찾아 데이터 덮어쓰기
-        db.collection("plans").document(planId)
-            .set(planWithTimestamp)
-            .await()
+        try {
+            db.collection("plans").document(planId)
+                .set(planWithTimestamp)
+                .await()
+            Log.i(TAG, "PlanRemoteDataSource: Successfully updated planId '$planId' in Firestore.")
+        } catch (e: Exception) {
+            Log.e(TAG, "PlanRemoteDataSource: Firestore update FAILED for planId '$planId'.", e)
+            throw e
+        }
     }
 
     /**

--- a/app/src/main/java/com/jeju/evtravel/data/repository/PlanRepositoryImpl.kt
+++ b/app/src/main/java/com/jeju/evtravel/data/repository/PlanRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.jeju.evtravel.data.repository
 
+import android.util.Log
 import com.jeju.evtravel.data.model.PlanDto
 import com.jeju.evtravel.data.remote.firebase.PlanRemoteDataSource
 import com.jeju.evtravel.domain.repository.PlanRepository
@@ -21,6 +22,8 @@ class PlanRepositoryImpl(
      * @param onSuccess 저장 성공 시 실행될 콜백 함수
      * @param onFailure 저장 실패 시 실행될 콜백 함수 (예외 전달)
      */
+    private val TAG = "PlannerDebug"
+    
     override fun savePlan(plan: PlanDto, onSuccess: () -> Unit, onFailure: (Exception) -> Unit) {
         // 원격 데이터 소스를 통해 플랜 저장 요청 전달
         remote.savePlan(plan, onSuccess, onFailure)
@@ -56,6 +59,11 @@ class PlanRepositoryImpl(
      * @param plan 업데이트할 플랜 데이터 (PlanDto)
      */
     suspend fun updatePlan(plan: PlanDto) {
-        remote.updatePlan(plan)
+        Log.d(TAG, "PlanRepositoryImpl: updatePlan called for planId '${plan.id}'.")
+        try {
+            remote.updatePlan(plan)
+        } catch (e: Exception) {
+            Log.e(TAG, "PlanRepositoryImpl: Exception caught while calling remote.updatePlan.", e)
+        }
     }
 }

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
@@ -1,20 +1,10 @@
 package com.jeju.evtravel.ui.planner
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -24,13 +14,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
@@ -69,6 +53,7 @@ fun EditPlanScreen(
     onAddDestinationClick: () -> Unit // 여행지 추가 버튼 클릭 시 실행될 콜백
 
 ) {
+    val TAG = "PlannerDebug"
     // 뷰모델에서 여행 시작일과 종료일을 상태로 가져옴
     val startDate = viewModel.startDate.collectAsState().value
     val endDate = viewModel.endDate.collectAsState().value
@@ -77,6 +62,8 @@ fun EditPlanScreen(
     val hasAnyPlace = dayPlans.any { it.places.isNotEmpty() }
     // 날짜 포맷터
     val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+    
+    val currentPlanId by viewModel.currentPlanId.collectAsState()
     
     val reorderableState = rememberReorderableLazyListState(onMove = { from, to ->
         val date = selectedDate
@@ -88,12 +75,18 @@ fun EditPlanScreen(
     
     // 화면 진입 시 플랜 ID가 있다면 해당 플랜을 로드합니다.
     LaunchedEffect(planId) {
-        if (planId != null) {
-            // ?. 를 추가하여 plans.value가 null이 아닐 때만 find를 실행합니다.
+        Log.d(TAG, "EditPlanScreen: LaunchedEffect triggered. Received planId is '$planId', ViewModel's currentPlanId is '$currentPlanId'.")
+        
+        if (planId != null && planId != currentPlanId) {
             val planToLoad = viewModel.plans.value?.find { it.id == planId }
             if (planToLoad != null) {
+                Log.d(TAG, "EditPlanScreen: Found plan in ViewModel list to load details for planId '$planId'.")
                 viewModel.loadPlanDetails(planToLoad)
+            } else {
+                Log.w(TAG, "EditPlanScreen: planId '$planId' was received, but no matching plan found in ViewModel's list.")
             }
+        } else {
+            Log.d(TAG, "EditPlanScreen: Skipping data load because planId is null or already loaded.")
         }
     }
     
@@ -471,6 +464,7 @@ fun EditPlanScreen(
                         )
                         .clickable {
                             if (startDate != null && endDate != null) {
+                                Log.d(TAG, "EditPlanScreen: 'Next' button clicked. Calling viewModel.saveOrUpdatePlan.")
                                 
                                 // 1. 화면 전환 로직을 onSaveComplete 라는 이름의 람다로 정의
                                 val onSaveComplete = {
@@ -481,7 +475,7 @@ fun EditPlanScreen(
                                 }
                                 
                                 // 2. ViewModel 함수를 호출하며 위에서 정의한 람다를 전달
-                                viewModel.saveCurrentPlan(
+                                viewModel.saveOrUpdatePlan(
                                     start = startDate.toString(),
                                     end = endDate.toString(),
                                     onSaveComplete = onSaveComplete

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
@@ -75,18 +75,30 @@ fun EditPlanScreen(
     
     // 화면 진입 시 플랜 ID가 있다면 해당 플랜을 로드합니다.
     LaunchedEffect(planId) {
-        Log.d(TAG, "EditPlanScreen: LaunchedEffect triggered. Received planId is '$planId', ViewModel's currentPlanId is '$currentPlanId'.")
+        Log.d(
+            TAG,
+            "EditPlanScreen: LaunchedEffect triggered. Received planId is '$planId', ViewModel's currentPlanId is '$currentPlanId'."
+        )
         
         if (planId != null && planId != currentPlanId) {
             val planToLoad = viewModel.plans.value?.find { it.id == planId }
             if (planToLoad != null) {
-                Log.d(TAG, "EditPlanScreen: Found plan in ViewModel list to load details for planId '$planId'.")
+                Log.d(
+                    TAG,
+                    "EditPlanScreen: Found plan in ViewModel list to load details for planId '$planId'."
+                )
                 viewModel.loadPlanDetails(planToLoad)
             } else {
-                Log.w(TAG, "EditPlanScreen: planId '$planId' was received, but no matching plan found in ViewModel's list.")
+                Log.w(
+                    TAG,
+                    "EditPlanScreen: planId '$planId' was received, but no matching plan found in ViewModel's list."
+                )
             }
         } else {
-            Log.d(TAG, "EditPlanScreen: Skipping data load because planId is null or already loaded.")
+            Log.d(
+                TAG,
+                "EditPlanScreen: Skipping data load because planId is null or already loaded."
+            )
         }
     }
     
@@ -270,6 +282,10 @@ fun EditPlanScreen(
                         if (selectedDate == dayPlan.date && dayPlan.places.isNotEmpty()) {
                             Column {
                                 dayPlan.places.forEach { place ->
+                                    Log.d(
+                                        "PlannerDebug",
+                                        "[2. UI 렌더링] '${place.name}' UI 생성 중. 포함된 충전소 개수: ${place.chargers?.size ?: "null"}"
+                                    )
                                     Column(modifier = Modifier.padding(bottom = 12.dp)) {
                                         Row(
                                             modifier = Modifier
@@ -436,7 +452,13 @@ fun EditPlanScreen(
                             color = Color(0xFFE9E9E9),
                             shape = RoundedCornerShape(size = 10.dp)
                         )
-                        .clickable { onAddDestinationClick() },
+                        .clickable {
+                            Log.d(
+                                "PlannerDebug",
+                                "Navigating to SearchScreen. Current state: selectedDate='${viewModel.selectedDate.value}', currentPlanId='${viewModel.currentPlanId.value}'"
+                            )
+                            onAddDestinationClick()
+                        },
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
@@ -464,7 +486,10 @@ fun EditPlanScreen(
                         )
                         .clickable {
                             if (startDate != null && endDate != null) {
-                                Log.d(TAG, "EditPlanScreen: 'Next' button clicked. Calling viewModel.saveOrUpdatePlan.")
+                                Log.d(
+                                    TAG,
+                                    "EditPlanScreen: 'Next' button clicked. Calling viewModel.saveOrUpdatePlan."
+                                )
                                 
                                 // 1. 화면 전환 로직을 onSaveComplete 라는 이름의 람다로 정의
                                 val onSaveComplete = {

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
@@ -1,5 +1,6 @@
 package com.jeju.evtravel.ui.planner
 
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -51,6 +52,7 @@ fun PlanListScreen(
     onCreatePlanClick: () -> Unit,  // "플랜 생성" 버튼 클릭 시 동작 (CalendarScreen으로 이동)
     onPlanClick: (PlanDto) -> Unit // EditPlanScreen으로 이동하는 콜백
 ) {
+    val TAG = "PlannerDebug"
     val plans by viewModel.plans.collectAsState()
     val plansList = plans ?: emptyList()
     
@@ -218,6 +220,7 @@ fun PlanListScreen(
             PlanItemBottomSheetContent(
                 onEditClick = {
                     selectedPlanForMenu?.let { plan ->
+                        Log.d(TAG, "PlanListScreen: 'Edit' clicked for planId '${plan.id}'. Calling onPlanClick.")
                         onPlanClick(plan)
                     }
                     scope.launch { editDeleteSheetState.hide() }.invokeOnCompletion {

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
@@ -90,12 +90,31 @@ class PlannerViewModel : ViewModel() {
      * @param query 검색어
      */
     fun searchPlaces(query: String, x: Double, y: Double) {
+        // 로그 추가: 함수가 호출되었는지 확인
+        Log.d("PlannerDebug", "searchPlaces CALLED with query: '$query'")
+        
         viewModelScope.launch {
-            if (query.isBlank()) {
-                _searchResults.value = emptyList() // 빈 문자열이면 결과 초기화
-            } else {
-                val results = searchPlaceUseCase(query, x, y)
-                _searchResults.value = results.map { UiPlace(place = it) }
+            try {
+                if (query.isBlank()) {
+                    _searchResults.value = emptyList()
+                } else {
+                    val results = searchPlaceUseCase(query, x, y)
+                    // 로그 추가: API 호출 후 받은 결과 수 확인
+                    Log.d("PlannerDebug", "API returned ${results.size} results. Filtering now...")
+                    
+                    val validResults = results.filter {
+                        !it.id.isNullOrBlank() && !it.name.isNullOrBlank()
+                    }
+                    // 로그 추가: 필터링 후 최종 결과 수 확인
+                    Log.d(
+                        "PlannerDebug",
+                        "After filtering, sending ${validResults.size} results to UI."
+                    )
+                    
+                    _searchResults.value = validResults.map { UiPlace(place = it) }
+                }
+            } catch (e: Exception) {
+                Log.e("PlannerDebug", "CRASH DETECTED in searchPlaces! Error: ${e.message}", e)
             }
         }
     }
@@ -128,6 +147,14 @@ class PlannerViewModel : ViewModel() {
                     days = _dayPlans.value,
                     userId = userId
                 )
+                newPlan.days.forEach { day ->
+                    day.places.forEach { place ->
+                        Log.d(
+                            "PlannerDebug",
+                            "[3. DB 저장] '${place.name}' 저장 예정. 충전소 개수: ${place.chargers?.size ?: "null"}"
+                        )
+                    }
+                }
                 savePlanUseCase(newPlan,
                     onSuccess = {
                         viewModelScope.launch {
@@ -137,7 +164,10 @@ class PlannerViewModel : ViewModel() {
                     }
                 )
             } else {
-                Log.i(TAG, "saveOrUpdatePlan: This is an UPDATE for planId '${_currentPlanId.value}'. Calling repository.updatePlan.")
+                Log.i(
+                    TAG,
+                    "saveOrUpdatePlan: This is an UPDATE for planId '${_currentPlanId.value}'. Calling repository.updatePlan."
+                )
                 val updatedPlan = PlanDto(
                     id = _currentPlanId.value!!,
                     startDate = start,
@@ -160,7 +190,10 @@ class PlannerViewModel : ViewModel() {
                 } else {
                     // 만약의 경우를 대비해 기존처럼 전체 목록을 다시 불러옴
                     _plans.value = repository.getPlans(userId)
-                    Log.d(TAG, "saveOrUpdatePlan: Plan not found in current list, re-fetching all plans.")
+                    Log.d(
+                        TAG,
+                        "saveOrUpdatePlan: Plan not found in current list, re-fetching all plans."
+                    )
                 }
                 // 3. 완료 콜백 실행
                 onSaveComplete()
@@ -195,6 +228,10 @@ class PlannerViewModel : ViewModel() {
      * @param place 추가할 장소
      */
     fun addPlaceToDate(date: String, place: PlaceDto) {
+        Log.d(
+            "PlannerDebug",
+            "[1. VM 도착] '${place.name}' 장소 추가 요청. 포함된 충전소 개수: ${place.chargers?.size ?: "null"}"
+        )
         _dayPlans.value = _dayPlans.value.map { dayPlan ->
             if (dayPlan.date == date) {
                 dayPlan.copy(places = dayPlan.places + place)
@@ -274,6 +311,19 @@ class PlannerViewModel : ViewModel() {
         _startDate.value = LocalDate.parse(plan.startDate)
         _endDate.value = LocalDate.parse(plan.endDate)
         _dayPlans.value = plan.days
+        
+        Log.d("PlannerDebug", "[3. DB 로드] Plan ID '${plan.id}' 로드 완료.")
+        plan.days.forEach { day ->
+            day.places.forEach { place ->
+                Log.d(
+                    "PlannerDebug",
+                    "[3. DB 로드] > '${place.name}' 로드 완료. 충전소 개수: ${place.chargers?.size ?: "null"}"
+                )
+            }
+        }
+        
+    }
+    
     }
     
     /**

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
@@ -1,5 +1,6 @@
 package com.jeju.evtravel.ui.planner
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jeju.evtravel.BuildConfig
@@ -23,13 +24,17 @@ import java.time.LocalDate
  */
 class PlannerViewModel : ViewModel() {
     // 의존성 주입 (실제 앱에서는 Hilt 등을 사용하여 주입)
+    private val TAG = "PlannerDebug"
     private val repository = PlanRepositoryImpl()
     private val savePlanUseCase = SavePlanUseCase(repository)
     
     // 현재 로그인된 사용자의 ID를 저장할 변수
     private var currentUserId: String? = null
     
-    // 날짜별 DayPlan 상태
+    // currentPlanId를 외부에서 관찰 가능한 StateFlow로 변경
+    private val _currentPlanId = MutableStateFlow<String?>(null)
+    val currentPlanId: StateFlow<String?> = _currentPlanId
+    
     private val _dayPlans = MutableStateFlow<List<DayPlan>>(emptyList())
     val dayPlans: StateFlow<List<DayPlan>> = _dayPlans
     
@@ -96,36 +101,70 @@ class PlannerViewModel : ViewModel() {
     }
     
     /**
-     * 현재 플랜을 저장합니다.
+     * 플랜을 새로 저장하거나 기존 플랜을 업데이트합니다.
      * @param start 여행 시작일 (yyyy-MM-dd 형식)
      * @param end 여행 종료일 (yyyy-MM-dd 형식)
+     * @param onSaveComplete 저장/업데이트 완료 후 실행할 콜백 함수
      */
-    fun saveCurrentPlan(
+    fun saveOrUpdatePlan(
         start: String,
         end: String,
         onSaveComplete: () -> Unit
     ) {
-        // 저장된 userId를 사용, 없으면 함수 종료
-        val userId = currentUserId ?: return
+        val userId = currentUserId
+        if (userId == null) {
+            Log.e(TAG, "saveOrUpdatePlan: Cannot save/update, currentUserId is null.")
+            return
+        }
+        
+        Log.d(TAG, "saveOrUpdatePlan: Function called. currentPlanId is '${_currentPlanId.value}'")
         
         viewModelScope.launch {
-            val plan = PlanDto(
-                startDate = start,
-                endDate = end,
-                days = _dayPlans.value,  // 날짜별 DayPlan 객체들 그대로 저장
-                userId = userId
-            )
-            
-            savePlanUseCase(plan,
-                onSuccess = {
-                    // 저장이 성공하면, 플랜 목록을 다시 불러옵니다.
-                    viewModelScope.launch {
-                        _plans.value = repository.getPlans(userId)
-                        // 목록 로드까지 완료되면, 파라미터로 받은 콜백(화면 전환)을 실행
-                        onSaveComplete()
+            if (_currentPlanId.value == null) {
+                Log.i(TAG, "saveOrUpdatePlan: This is a NEW plan. Calling savePlanUseCase.")
+                val newPlan = PlanDto(
+                    startDate = start,
+                    endDate = end,
+                    days = _dayPlans.value,
+                    userId = userId
+                )
+                savePlanUseCase(newPlan,
+                    onSuccess = {
+                        viewModelScope.launch {
+                            _plans.value = repository.getPlans(userId)
+                            onSaveComplete()
+                        }
                     }
+                )
+            } else {
+                Log.i(TAG, "saveOrUpdatePlan: This is an UPDATE for planId '${_currentPlanId.value}'. Calling repository.updatePlan.")
+                val updatedPlan = PlanDto(
+                    id = _currentPlanId.value!!,
+                    startDate = start,
+                    endDate = end,
+                    days = _dayPlans.value,
+                    userId = userId
+                )
+                Log.d(TAG, "saveOrUpdatePlan: Plan data to be updated: $updatedPlan")
+                
+                // 1. Firestore에 업데이트
+                repository.updatePlan(updatedPlan)
+                
+                // 2. 서버에서 다시 불러오는 대신, 현재 ViewModel이 가진 plans 목록을 직접 수정
+                val currentPlans = _plans.value?.toMutableList() ?: mutableListOf()
+                val index = currentPlans.indexOfFirst { it.id == updatedPlan.id }
+                if (index != -1) {
+                    currentPlans[index] = updatedPlan // 기존 아이템을 업데이트된 내용으로 교체
+                    _plans.value = currentPlans // 갱신된 리스트를 StateFlow에 반영
+                    Log.d(TAG, "saveOrUpdatePlan: Manually updated ViewModel state.")
+                } else {
+                    // 만약의 경우를 대비해 기존처럼 전체 목록을 다시 불러옴
+                    _plans.value = repository.getPlans(userId)
+                    Log.d(TAG, "saveOrUpdatePlan: Plan not found in current list, re-fetching all plans.")
                 }
-            )
+                // 3. 완료 콜백 실행
+                onSaveComplete()
+            }
         }
     }
     
@@ -228,6 +267,10 @@ class PlannerViewModel : ViewModel() {
      * @param plan 화면에 표시할 플랜 데이터
      */
     fun loadPlanDetails(plan: PlanDto) {
+        Log.d(TAG, "loadPlanDetails: Loading details for plan ID '${plan.id}'.")
+        _currentPlanId.value = plan.id
+        Log.d(TAG, "loadPlanDetails: currentPlanId is now set to '${_currentPlanId.value}'.")
+        
         _startDate.value = LocalDate.parse(plan.startDate)
         _endDate.value = LocalDate.parse(plan.endDate)
         _dayPlans.value = plan.days
@@ -238,6 +281,8 @@ class PlannerViewModel : ViewModel() {
      * (새로운 플랜 생성 시작 시 사용)
      */
     fun clearPlanDetails() {
+        Log.d(TAG, "clearPlanDetails: Clearing all plan details. Resetting currentPlanId.")
+        _currentPlanId.value = null
         _startDate.value = null
         _endDate.value = null
         _dayPlans.value = emptyList()

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jeju.evtravel.BuildConfig
+import com.jeju.evtravel.data.model.ChargerDto
 import com.jeju.evtravel.data.model.DayPlan
 import com.jeju.evtravel.data.model.PlaceDto
 import com.jeju.evtravel.data.model.PlanDto
@@ -324,6 +325,60 @@ class PlannerViewModel : ViewModel() {
         
     }
     
+    /**
+     * 장소와 함께 충전소 정보를 로드하여 PlaceDto를 생성합니다.
+     * @param place 기본 장소 정보
+     * @param onResult 결과를 받을 콜백 함수
+     */
+    fun loadPlaceWithChargers(place: UiPlace, onResult: (PlaceDto) -> Unit) {
+        viewModelScope.launch {
+            try {
+                // 충전소 정보를 먼저 로드
+                val chargers = chargerRepository.getNearbyChargers(
+                    lat = place.place.latitude,
+                    lon = place.place.longitude
+                ).take(5)
+                
+                val placeChargers = chargers.map {
+                    ChargerDto(
+                        name = it.name,
+                        address = it.address,
+                        latitude = it.latitude,
+                        longitude = it.longitude
+                    )
+                }
+                
+                val placeDto = PlaceDto(
+                    id = place.place.id,
+                    name = place.place.name,
+                    roadAddressName = place.place.roadAddress ?: "",
+                    categoryGroupCode = "",
+                    x = place.place.longitude,
+                    y = place.place.latitude,
+                    chargers = placeChargers
+                )
+                
+                Log.d(
+                    "PlannerDebug",
+                    "[0. 장소 선택] '${placeDto.name}' 선택됨. 충전소 개수: ${placeChargers.size}"
+                )
+                onResult(placeDto)
+                
+            } catch (e: Exception) {
+                Log.e("PlannerDebug", "충전소 로드 실패: ${e.message}")
+                // 충전소 로드 실패시에도 장소는 추가할 수 있도록
+                val placeDto = PlaceDto(
+                    id = place.place.id,
+                    name = place.place.name,
+                    roadAddressName = place.place.roadAddress ?: "",
+                    categoryGroupCode = "",
+                    x = place.place.longitude,
+                    y = place.place.latitude,
+                    chargers = emptyList()
+                )
+                onResult(placeDto)
+            }
+        }
     }
     
     /**

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/SearchDestinationScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/SearchDestinationScreen.kt
@@ -1,5 +1,6 @@
 package com.jeju.evtravel.ui.planner
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -28,6 +29,7 @@ import com.jeju.evtravel.data.model.PlaceDto
 import androidx.compose.ui.res.painterResource
 import com.jeju.evtravel.R
 import com.jeju.evtravel.data.model.ChargerDto
+import kotlinx.coroutines.launch
 
 /**
  * 목적지 검색 화면을 구현하는 Composable 함수
@@ -46,6 +48,7 @@ fun SearchDestinationScreen(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     var selectedPlace by remember { mutableStateOf<PlaceDto?>(null) }
+    val viewModelScope = rememberCoroutineScope()
     
     Box(
         modifier = Modifier
@@ -111,7 +114,12 @@ fun SearchDestinationScreen(
                     BasicTextField(
                         value = query,
                         onValueChange = {
+                            // 로그 추가: 어떤 글자가 입력되었는지 확인
+                            Log.d("PlannerDebug", "onValueChange: new text is '${it.text}'")
                             query = it
+                            
+                            // 로그 추가: ViewModel 함수를 호출하기 직전인지 확인
+                            Log.d("PlannerDebug", "Calling viewModel.searchPlaces...")
                             viewModel.searchPlaces(it.text, x, y)
                         },
                         textStyle = TextStyle(

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/SearchDestinationScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/SearchDestinationScreen.kt
@@ -162,24 +162,10 @@ fun SearchDestinationScreen(
                         .fillMaxWidth()
                         .padding(vertical = 12.dp)
                         .clickable {
-                            val placeChargers = uiPlace.chargers?.map {
-                                ChargerDto(
-                                    name = it.name,
-                                    address = it.address,
-                                    latitude = it.latitude,
-                                    longitude = it.longitude
-                                )
-                            } ?: emptyList()
-                            
-                            selectedPlace = PlaceDto(
-                                id = uiPlace.place.id,
-                                name = uiPlace.place.name,
-                                roadAddressName = uiPlace.place.roadAddress ?: "",
-                                categoryGroupCode = "",
-                                x = uiPlace.place.longitude,
-                                y = uiPlace.place.latitude,
-                                chargers = placeChargers
-                            )
+                            // ViewModel의 새로운 함수를 사용하여 충전소 정보와 함께 장소 로드
+                            viewModel.loadPlaceWithChargers(uiPlace) { placeWithChargers ->
+                                selectedPlace = placeWithChargers
+                            }
                         },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -235,7 +221,8 @@ fun SearchDestinationScreen(
                         ),
                         contentDescription = "select",
                         contentScale = ContentScale.Fit,
-                        modifier = Modifier.size(22.dp)
+                        modifier = Modifier
+                            .size(22.dp)
                     )
                 }
                 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)

- [ ]  기능 추가
- [ ]  기능 삭제
- [x]  버그 수정
- [ ]  문서 수정
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  파일 혹은 폴더명 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

`feature/planner` → `develop`

### 변경 사항

플래너의 플랜 수정 및 생성 기능에서 발생하던 다수의 버그를 해결하고 코드 안정성을 개선했습니다.

- **플랜 업데이트 로직 수정**
    - 기존 플랜 수정 시 새로운 플랜이 생성되던 오류를 해결했습니다. (`saveOrUpdatePlan` 로직 분리)
    - 업데이트 후 목록 화면에 변경사항이 즉시 반영되지 않던 데이터 동기화 문제를 해결했습니다. (Firestore 재조회 대신 로컬 상태 직접 수정)
    
- **ViewModel 상태 관리 로직 개선**
    - 새로운 플랜 생성 시, 이전에 편집하던 플랜 정보를 덮어쓰는 문제를 해결했습니다. (`clearPlanDetails` 호출 로직 추가)
    - 플랜 편집 화면 진입 시, 불필요한 데이터 재로드로 인해 사용자 수정 내용이 초기화되는 현상을 방지했습니다. (`LaunchedEffect` 내 중복 로드 방지)

### 테스트 결과

모든 시나리오에서 정상 동작을 확인했습니다.

- **시나리오 1: 기존 플랜 수정**
    - **테스트 내용**: 플랜 목록에서 기존 플랜을 선택하여 장소를 추가/삭제한 후 저장.
    - **결과**: 새로운 플랜이 생성되지 않고, 기존 플랜의 내용이 정상적으로 업데이트되는 것을 Firestore와 앱 화면에서 확인.
    
- **시나리오 2: 새 플랜 생성**
    - **테스트 내용**: 기존 플랜을 한번 편집하고 나온 뒤, 새로운 플랜을 생성.
    - **결과**: 이전에 편집했던 플랜에 영향을 주지 않고, 새로운 플랜이 정상적으로 생성되는 것을 확인.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 편집 시 저장/업데이트가 통합되어 기존 계획을 바로 수정·반영할 수 있습니다.
  - 목적지 검색 선택 시 충전소 정보를 자동으로 불러와 선택된 장소에 반영합니다.
- 버그 수정
  - 새 일정 생성 전 상태를 초기화해 이전 계획 정보가 남는 문제를 방지했습니다.
  - 편집 화면의 불필요한 재로딩을 줄여 깜빡임을 완화했습니다.
  - 계획 업데이트 처리 안정성(오류 처리 및 동기화)을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->