### PR TITLE
fix: 위치 정보 접근 실패 시 기본 좌표 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,8 +119,8 @@ android {
 
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = true
-            isShrinkResources = true
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/src/main/java/com/jeju/evtravel/MainActivity.kt
+++ b/app/src/main/java/com/jeju/evtravel/MainActivity.kt
@@ -328,13 +328,24 @@ fun MainScreen(
                     LaunchedEffect(Unit) {
                         try {
                             fusedLocationClient.lastLocation.addOnSuccessListener { location ->
-                                location?.let {
-                                    x = it.longitude
-                                    y = it.latitude
+                                if (location != null) {
+                                    x = location.longitude
+                                    y = location.latitude
+                                } else {
+                                    // 위치 정보를 가져올 수 없는 경우 기본 좌표 설정
+                                    x = 126.53112475064323
+                                    y = 33.499545786637974
                                 }
+                            }.addOnFailureListener {
+                                // 위치 가져오기 실패시 기본 좌표 설정
+                                x = 126.53112475064323
+                                y = 33.499545786637974
                             }
                         } catch (e: SecurityException) {
                             Log.e("Location", "Location permission not granted: ${e.message}")
+                            // 권한 없을 때도 기본 좌표 설정
+                            x = 126.53112475064323
+                            y = 33.499545786637974
                         }
                     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`fix/planner` → `develop`

### 변경 사항
- 위치 정보(`location`) 접근 실패 시 기본 좌표를 설정하여 검색 시 무한 로딩 문제 해결
- Gradle JVM 메모리 옵션 `2GB → 4GB`로 확장하여 빌드 안정성 개선
- 릴리즈 빌드 시 코드 및 리소스 난독화 비활성화 설정 (배포 시 카카오 api 호출 때문에)
### 테스트 결과
- 위치 권한이 없거나 GPS 신호를 받을 수 없는 경우에도 앱이 정상적으로 검색 기능 가능
- 빌드 시 메모리 부족 오류 없이 정상적으로 빌드 완료됨 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 위치 정보가 null이거나 조회 실패·권한 예외 발생 시 기본 좌표를 사용해 검색 화면이 정상 표시되도록 개선하여 로딩 지연/오류를 감소시켰습니다.

- 작업(Chores)
  - 릴리스 빌드에서 코드 난독화 및 리소스 축소를 비활성화하여 빌드 안정성을 높였습니다.
  - Gradle JVM 메모리를 2GB에서 4GB로 증설하여 빌드 성능과 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->