### PR TITLE
feat: 플랜 조회 기능 추가 및 라우팅 개선

### DIFF
--- a/app/src/main/java/com/jeju/evtravel/MainActivity.kt
+++ b/app/src/main/java/com/jeju/evtravel/MainActivity.kt
@@ -40,7 +40,7 @@ import com.jeju.evtravel.ui.detail.PlaceDetailScreen
 import com.jeju.evtravel.ui.detail.SummarizePlaceViewModel
 import com.jeju.evtravel.ui.detail.TourPlaceDetailViewModel
 import com.jeju.evtravel.ui.detail.course.CourseDetailScreen
-import com.jeju.evtravel.ui.detail.course.CourseViewModel
+import com.jeju.evtravel.ui.planner.ViewPlanScreen
 import com.jeju.evtravel.ui.map.KakaoMapScreen
 import com.jeju.evtravel.ui.map.MapViewModel
 import com.jeju.evtravel.ui.mypage.MyPageScreen
@@ -373,8 +373,11 @@ fun MainScreen(
                             plannerViewModel.clearPlanDetails()
                             navController.navigate("calendar")
                         },
-                        onPlanClick = { plan ->
+                        onPlanEditClick = { plan -> // 편집 클릭 시 EditPlanScreen으로 이동
                             navController.navigate("editPlan/${plan.id}")
+                        },
+                        onPlanViewClick = { plan -> // 상세 보기 클릭 시 ViewPlanScreen으로 이동
+                            navController.navigate("viewPlan/${plan.id}")
                         }
                     )
                 }
@@ -405,7 +408,19 @@ fun MainScreen(
                         onAddDestinationClick = { navController.navigate("searchDestination") }
                     )
                 }
-
+                
+                composable(
+                    route = "viewPlan/{planId}",
+                    arguments = listOf(navArgument("planId") { type = NavType.StringType })
+                ) { backStackEntry ->
+                    val planId = backStackEntry.arguments?.getString("planId")
+                    ViewPlanScreen(
+                        viewModel = plannerViewModel,
+                        planId = planId,
+                        onBackClick = { navController.popBackStack() }
+                    )
+                }
+                
                 // 여행지 검색 화면 (하단바 숨김)
                 composable("searchDestination") {
                     var x by remember { mutableStateOf<Double?>(null) }

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/EditPlanScreen.kt
@@ -278,157 +278,154 @@ fun EditPlanScreen(
                         .reorderable(reorderableState)
                         .detectReorderAfterLongPress(reorderableState)
                 ) {
-                    itemsIndexed(dayPlans, key = { _, plan -> plan.date }) { _, dayPlan ->
-                        if (selectedDate == dayPlan.date && dayPlan.places.isNotEmpty()) {
-                            Column {
-                                dayPlan.places.forEach { place ->
-                                    Log.d(
-                                        "PlannerDebug",
-                                        "[2. UI 렌더링] '${place.name}' UI 생성 중. 포함된 충전소 개수: ${place.chargers?.size ?: "null"}"
+                    itemsIndexed(
+                        dayPlans.find { it.date == selectedDate }?.places ?: emptyList(),
+                        key = { _, place -> place.id }
+                    ) { _, place ->
+                        Log.d(
+                            "PlannerDebug",
+                            "[2. UI 렌더링] '${place.name}' UI 생성 중. 포함된 충전소 개수: ${place.chargers?.size ?: "null"}"
+                        )
+                        Column(modifier = Modifier.padding(bottom = 12.dp)) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(60.dp)
+                                    .shadow(
+                                        elevation = 4.dp,
+                                        shape = RoundedCornerShape(10.dp),
+                                        ambientColor = Color(0x40A7A7A7),
+                                        spotColor = Color(0x40A7A7A7)
                                     )
-                                    Column(modifier = Modifier.padding(bottom = 12.dp)) {
-                                        Row(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .height(60.dp)
-                                                .shadow(
-                                                    elevation = 4.dp,
-                                                    shape = RoundedCornerShape(10.dp),
-                                                    ambientColor = Color(0x40A7A7A7),
-                                                    spotColor = Color(0x40A7A7A7)
-                                                )
-                                                .background(
-                                                    Color.White,
-                                                    shape = RoundedCornerShape(10.dp)
-                                                ),
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Icon(
-                                                painter = painterResource(id = R.drawable.ic_menu),
-                                                contentDescription = "메뉴",
-                                                tint = Color.Black,
-                                                modifier = Modifier
-                                                    .padding(start = 16.dp)
-                                                    .size(18.dp)
-                                            )
-                                            
-                                            Text(
-                                                text = place.name,
-                                                style = TextStyle(
-                                                    fontSize = 15.sp,
-                                                    fontWeight = FontWeight.SemiBold,
-                                                    fontFamily = FontFamily(Font(R.font.roboto)),
-                                                    color = Color(0xFF1C1917)
-                                                ),
-                                                modifier = Modifier
-                                                    .weight(1f) // Row 내부에서 weight 사용
-                                                    .padding(start = 16.dp)
-                                            )
-                                            
-                                            val chargerIconId = if (expandedPlaceId == place.id) {
-                                                R.drawable.ic_charger_on // 선택 시 ic_charger_on
-                                            } else {
-                                                R.drawable.ic_charger_off // 미선택 시 ic_charger_off
-                                            }
-                                            
-                                            Icon(
-                                                painter = painterResource(id = chargerIconId),
-                                                contentDescription = "충전 현황",
-                                                tint = if (expandedPlaceId == place.id) Color(
-                                                    0xFF000000
-                                                ) else Color(0xFF9D9D9D),
-                                                modifier = Modifier
-                                                    .padding(end = 12.dp)
-                                                    .size(20.dp)
-                                                    .clickable {
-                                                        expandedPlaceId =
-                                                            if (expandedPlaceId == place.id) null else place.id
-                                                    }
-                                            )
-                                            IconButton(
-                                                onClick = {
-                                                    viewModel.removePlaceFromDate(
-                                                        dayPlan.date,
-                                                        place.id
-                                                    )
-                                                },
-                                                modifier = Modifier
-                                                    .padding(end = 16.dp)
-                                                    .size(20.dp)
-                                            ) {
-                                                Icon(
-                                                    painter = painterResource(id = R.drawable.ic_close),
-                                                    contentDescription = "삭제",
-                                                    tint = Color.Black
-                                                )
-                                            }
+                                    .background(
+                                        Color.White,
+                                        shape = RoundedCornerShape(10.dp)
+                                    ),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(
+                                    painter = painterResource(id = R.drawable.ic_menu),
+                                    contentDescription = "메뉴",
+                                    tint = Color.Black,
+                                    modifier = Modifier
+                                        .padding(start = 16.dp)
+                                        .size(18.dp)
+                                )
+                                
+                                Text(
+                                    text = place.name,
+                                    style = TextStyle(
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        fontFamily = FontFamily(Font(R.font.roboto)),
+                                        color = Color(0xFF1C1917)
+                                    ),
+                                    modifier = Modifier
+                                        .weight(1f) // Row 내부에서 weight 사용
+                                        .padding(start = 16.dp)
+                                )
+                                
+                                val chargerIconId = if (expandedPlaceId == place.id) {
+                                    R.drawable.ic_charger_on // 선택 시 ic_charger_on
+                                } else {
+                                    R.drawable.ic_charger_off // 미선택 시 ic_charger_off
+                                }
+                                
+                                Icon(
+                                    painter = painterResource(id = chargerIconId),
+                                    contentDescription = "충전 현황",
+                                    tint = if (expandedPlaceId == place.id) Color(
+                                        0xFF000000
+                                    ) else Color(0xFF9D9D9D),
+                                    modifier = Modifier
+                                        .padding(end = 12.dp)
+                                        .size(20.dp)
+                                        .clickable {
+                                            expandedPlaceId =
+                                                if (expandedPlaceId == place.id) null else place.id
                                         }
-                                        
-                                        // 충전소 목록
-                                        if (expandedPlaceId == place.id && !place.chargers.isNullOrEmpty()) {
-                                            Column(
-                                                modifier = Modifier
-                                                    .padding(start = 8.dp, end = 0.dp)
-                                                    .offset(y = (-4).dp)
-                                            ) {
-                                                Box(
-                                                    modifier = Modifier
-                                                        .fillMaxWidth()
-                                                        .shadow(
-                                                            elevation = 4.dp,
-                                                            spotColor = Color(0x40A7A7A7),
-                                                            ambientColor = Color(0x40A7A7A7),
-                                                            shape = RoundedCornerShape(
-                                                                bottomStart = 10.dp,
-                                                                bottomEnd = 10.dp
-                                                            )
-                                                        )
-                                                        .background(
-                                                            color = Color(0xFFFFFFFF),
-                                                            shape = RoundedCornerShape(
-                                                                bottomStart = 10.dp,
-                                                                bottomEnd = 10.dp
-                                                            )
-                                                        )
-                                                        .padding(
-                                                            vertical = 12.dp,
-                                                            horizontal = 16.dp
-                                                        )
+                                )
+                                IconButton(
+                                    onClick = {
+                                        viewModel.removePlaceFromDate(
+                                            selectedDate!!,
+                                            place.id
+                                        )
+                                    },
+                                    modifier = Modifier
+                                        .padding(end = 16.dp)
+                                        .size(20.dp)
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = R.drawable.ic_close),
+                                        contentDescription = "삭제",
+                                        tint = Color.Black
+                                    )
+                                }
+                            }
+                            
+                            // 충전소 목록
+                            if (expandedPlaceId == place.id && !place.chargers.isNullOrEmpty()) {
+                                Column(
+                                    modifier = Modifier
+                                        .padding(start = 8.dp, end = 0.dp)
+                                        .offset(y = (-4).dp)
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .shadow(
+                                                elevation = 4.dp,
+                                                spotColor = Color(0x40A7A7A7),
+                                                ambientColor = Color(0x40A7A7A7),
+                                                shape = RoundedCornerShape(
+                                                    bottomStart = 10.dp,
+                                                    bottomEnd = 10.dp
+                                                )
+                                            )
+                                            .background(
+                                                color = Color(0xFFFFFFFF),
+                                                shape = RoundedCornerShape(
+                                                    bottomStart = 10.dp,
+                                                    bottomEnd = 10.dp
+                                                )
+                                            )
+                                            .padding(
+                                                vertical = 12.dp,
+                                                horizontal = 16.dp
+                                            )
+                                    ) {
+                                        Column {
+                                            place.chargers!!.forEachIndexed { index, charger ->
+                                                Row(
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    verticalAlignment = Alignment.CenterVertically
                                                 ) {
-                                                    Column {
-                                                        place.chargers!!.forEachIndexed { index, charger ->
-                                                            Row(
-                                                                modifier = Modifier.fillMaxWidth(),
-                                                                verticalAlignment = Alignment.CenterVertically
-                                                            ) {
-                                                                Text(
-                                                                    text = charger.name,
-                                                                    style = TextStyle(
-                                                                        fontSize = 14.sp,
-                                                                        fontFamily = FontFamily(
-                                                                            Font(
-                                                                                R.font.roboto
-                                                                            )
-                                                                        ),
-                                                                        fontWeight = FontWeight(400),
-                                                                        color = Color(0xFF000000),
-                                                                    )
+                                                    Text(
+                                                        text = charger.name,
+                                                        style = TextStyle(
+                                                            fontSize = 14.sp,
+                                                            fontFamily = FontFamily(
+                                                                Font(
+                                                                    R.font.roboto
                                                                 )
-                                                            }
-                                                            
-                                                            // 마지막 아이템이 아닌 경우에만 구분선 추가
-                                                            if (index < place.chargers.size - 1) {
-                                                                Spacer(modifier = Modifier.height(8.dp))
-                                                                Box(
-                                                                    modifier = Modifier
-                                                                        .fillMaxWidth()
-                                                                        .height(0.5.dp)
-                                                                        .background(Color(0xFFDBDBDB))
-                                                                )
-                                                                Spacer(modifier = Modifier.height(8.dp))
-                                                            }
-                                                        }
-                                                    }
+                                                            ),
+                                                            fontWeight = FontWeight(400),
+                                                            color = Color(0xFF000000),
+                                                        )
+                                                    )
+                                                }
+                                                
+                                                // 마지막 아이템이 아닌 경우에만 구분선 추가
+                                                if (index < place.chargers.size - 1) {
+                                                    Spacer(modifier = Modifier.height(8.dp))
+                                                    Box(
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .height(0.5.dp)
+                                                            .background(Color(0xFFDBDBDB))
+                                                    )
+                                                    Spacer(modifier = Modifier.height(8.dp))
                                                 }
                                             }
                                         }
@@ -437,45 +434,45 @@ fun EditPlanScreen(
                             }
                         }
                     }
+                    
+                    // 여행지 추가 버튼
+                    item {
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(59.dp)
+                                .background(
+                                    color = Color(0xFFE9E9E9),
+                                    shape = RoundedCornerShape(size = 10.dp)
+                                )
+                                .clickable {
+                                    Log.d(
+                                        "PlannerDebug",
+                                        "Navigating to SearchScreen. Current state: selectedDate='${viewModel.selectedDate.value}', currentPlanId='${viewModel.currentPlanId.value}'"
+                                    )
+                                    onAddDestinationClick()
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = " + 여행지 추가하기",
+                                style = TextStyle(
+                                    fontSize = 15.sp,
+                                    lineHeight = 24.sp,
+                                    fontFamily = FontFamily(Font(R.font.roboto)),
+                                    fontWeight = FontWeight(700),
+                                    color = Color(0xFF9D9D9D),
+                                )
+                            )
+                        }
+                    }
                 }
             }
             
-            // 하단 버튼 영역을 LazyColumn과 분리하여 Column 내부에서 관리
+            // "다음" 버튼은 Column의 가장 아래에 고정
             Spacer(modifier = Modifier.height(12.dp))
             if (hasAnyPlace) {
-                // 여행지 추가 버튼
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(59.dp)
-                        .background(
-                            color = Color(0xFFE9E9E9),
-                            shape = RoundedCornerShape(size = 10.dp)
-                        )
-                        .clickable {
-                            Log.d(
-                                "PlannerDebug",
-                                "Navigating to SearchScreen. Current state: selectedDate='${viewModel.selectedDate.value}', currentPlanId='${viewModel.currentPlanId.value}'"
-                            )
-                            onAddDestinationClick()
-                        },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = " + 여행지 추가하기",
-                        style = TextStyle(
-                            fontSize = 15.sp,
-                            lineHeight = 24.sp,
-                            fontFamily = FontFamily(Font(R.font.roboto)),
-                            fontWeight = FontWeight(700),
-                            color = Color(0xFF9D9D9D),
-                        )
-                    )
-                }
-                
-                Spacer(modifier = Modifier.height(12.dp))
-                
-                // "다음" 버튼
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -490,16 +487,12 @@ fun EditPlanScreen(
                                     TAG,
                                     "EditPlanScreen: 'Next' button clicked. Calling viewModel.saveOrUpdatePlan."
                                 )
-                                
-                                // 1. 화면 전환 로직을 onSaveComplete 라는 이름의 람다로 정의
                                 val onSaveComplete = {
                                     navController.navigate("planList?start=${startDate}&end=${endDate}") {
                                         popUpTo("planList") { inclusive = true }
                                         launchSingleTop = true
                                     }
                                 }
-                                
-                                // 2. ViewModel 함수를 호출하며 위에서 정의한 람다를 전달
                                 viewModel.saveOrUpdatePlan(
                                     start = startDate.toString(),
                                     end = endDate.toString(),

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlanListScreen.kt
@@ -50,7 +50,8 @@ fun PlanListScreen(
     selectedEnd: String? = null,    // 새로 생성된 플랜의 종료일 (강조 표시용)
     onBackClick: () -> Unit,        // 상단 뒤로가기 버튼 클릭 시 동작
     onCreatePlanClick: () -> Unit,  // "플랜 생성" 버튼 클릭 시 동작 (CalendarScreen으로 이동)
-    onPlanClick: (PlanDto) -> Unit // EditPlanScreen으로 이동하는 콜백
+    onPlanEditClick: (PlanDto) -> Unit, // onPlanClick -> onPlanEditClick으로 변경
+    onPlanViewClick: (PlanDto) -> Unit // onViewClick 콜백 추가
 ) {
     val TAG = "PlannerDebug"
     val plans by viewModel.plans.collectAsState()
@@ -165,7 +166,8 @@ fun PlanListScreen(
                     onMenuClick = { plan ->
                         selectedPlanForMenu = plan
                         showEditDeleteSheet = true
-                    }
+                    },
+                    onViewClick = onPlanViewClick // onPlanViewClick 콜백 전달
                 )
             }
             
@@ -220,8 +222,8 @@ fun PlanListScreen(
             PlanItemBottomSheetContent(
                 onEditClick = {
                     selectedPlanForMenu?.let { plan ->
-                        Log.d(TAG, "PlanListScreen: 'Edit' clicked for planId '${plan.id}'. Calling onPlanClick.")
-                        onPlanClick(plan)
+                        Log.d(TAG, "PlanListScreen: 'Edit' clicked for planId '${plan.id}'. Calling onPlanEditClick.")
+                        onPlanEditClick(plan)
                     }
                     scope.launch { editDeleteSheetState.hide() }.invokeOnCompletion {
                         showEditDeleteSheet = false
@@ -244,7 +246,8 @@ fun PlanListForDate(
     selectedDate: LocalDate,
     plans: List<PlanDto>,
     highlightedPlan: Pair<String, String>?,
-    onMenuClick: (PlanDto) -> Unit
+    onMenuClick: (PlanDto) -> Unit,
+    onViewClick: (PlanDto) -> Unit // 새로운 onViewClick 매개변수 추가
 ) {
     // 날짜 포맷 지정: "yyyy년 M월 d일"
     val dateFormatter = DateTimeFormatter.ofPattern("yyyy년 M월 d일", Locale.KOREAN)
@@ -290,7 +293,8 @@ fun PlanListForDate(
                     PlanItem(
                         plan = plan,
                         isHighlighted = isHighlighted,
-                        onMenuClick = { onMenuClick(plan) }
+                        onMenuClick = { onMenuClick(plan) },
+                        onViewClick = { onViewClick(plan) } // onViewClick 콜백 전달
                     )
                 }
             }
@@ -510,7 +514,8 @@ fun PlanIndicator(isStart: Boolean, isEnd: Boolean) {
 fun PlanItem(
     plan: PlanDto,
     isHighlighted: Boolean = false,
-    onMenuClick: (PlanDto) -> Unit
+    onMenuClick: (PlanDto) -> Unit,
+    onViewClick: (PlanDto) -> Unit // 새로운 onViewClick 콜백 추가
 ) {
     Row(
         modifier = Modifier
@@ -523,6 +528,10 @@ fun PlanItem(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Row(
+            // 이 부분을 클릭했을 때 상세 보기 화면으로 이동
+            modifier = Modifier
+                .weight(1f) // Text와 Icon이 포함된 Row에 weight를 주어 나머지 공간을 차지하게 함
+                .clickable { onViewClick(plan) }, // 클릭 리스너를 이 Row에 추가
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
@@ -539,6 +548,7 @@ fun PlanItem(
             )
         }
         
+        // 더보기 아이콘은 onMenuClick만 호출
         Image(
             painter = painterResource(id = R.drawable.ic_list_menu),
             contentDescription = "더보기",

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/PlannerScreen.kt
@@ -33,7 +33,7 @@ fun PlannerScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(Color(0xFFF8F8F8))
             .padding(horizontal = 24.dp),  // 좌우 여백 24dp
         contentAlignment = Alignment.Center  // 중앙 정렬
     ) {

--- a/app/src/main/java/com/jeju/evtravel/ui/planner/ViewPlanScreen.kt
+++ b/app/src/main/java/com/jeju/evtravel/ui/planner/ViewPlanScreen.kt
@@ -1,0 +1,319 @@
+package com.jeju.evtravel.ui.planner
+
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.jeju.evtravel.R
+import com.jeju.evtravel.ui.theme.Variables
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.navigation.NavController
+
+/**
+ * 여행 일정을 조회하는 화면 (읽기 전용)
+ *
+ * @param viewModel 플래너 뷰모델
+ * @param onBackClick 뒤로가기 버튼 클릭 시 실행될 콜백
+ */
+@Composable
+fun ViewPlanScreen(
+    viewModel: PlannerViewModel,
+    planId: String?,
+    onBackClick: () -> Unit,
+) {
+    val TAG = "PlannerDebug"
+    
+    // 뷰모델에서 여행 시작일과 종료일을 상태로 가져옴
+    val startDate by viewModel.startDate.collectAsState()
+    val endDate by viewModel.endDate.collectAsState()
+    val dayPlans by viewModel.dayPlans.collectAsState()
+    val selectedDate by viewModel.selectedDate.collectAsState()
+    
+    // 날짜 포맷터
+    val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+    
+    // 충전소 목록 확장 상태
+    var expandedPlaceId by remember { mutableStateOf<String?>(null) }
+    
+    // 화면 진입 시 플랜 ID가 있다면 해당 플랜을 로드합니다.
+    LaunchedEffect(planId) {
+        Log.d(
+            TAG,
+            "ViewPlanScreen: LaunchedEffect triggered. Received planId is '$planId'."
+        )
+        
+        if (planId != null) {
+            val planToLoad = viewModel.plans.value?.find { it.id == planId }
+            if (planToLoad != null) {
+                viewModel.loadPlanDetails(planToLoad)
+            }
+        }
+    }
+    
+    LaunchedEffect(dayPlans) {
+        if (selectedDate == null && dayPlans.isNotEmpty()) {
+            viewModel.setSelectedDate(dayPlans.first().date)
+        }
+    }
+    
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(start = 24.dp, top = 84.dp)
+                .size(22.dp)
+                .clickable { onBackClick() },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_back),
+                contentDescription = "뒤로가기",
+                tint = Color.Unspecified,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = 136.dp, start = 24.dp, end = 24.dp, bottom = 16.dp)
+        ) {
+            // "여행 기간" 헤더
+            Text(
+                text = "여행 기간",
+                style = TextStyle(
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily(Font(R.font.roboto)),
+                    color = Color.Black
+                )
+            )
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            startDate?.let { start ->
+                endDate?.let { end ->
+                    Text(
+                        text = "${start.format(formatter)} ~ ${end.format(formatter)}",
+                        style = TextStyle(
+                            fontSize = 20.sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily(Font(R.font.roboto)),
+                            color = Color.Black
+                        )
+                    )
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(32.dp))
+            
+            // "여행 일정" 헤더
+            Text(
+                text = "여행 일정",
+                style = TextStyle(
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight(700),
+                    fontFamily = FontFamily(Font(R.font.roboto)),
+                    color = Color.Black
+                )
+            )
+            
+            Spacer(modifier = Modifier.height(16.dp))
+            
+            // 날짜 선택 버튼 LazyRow
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                items(dayPlans) { dayPlan ->
+                    val localDate = LocalDate.parse(dayPlan.date)
+                    val dayOfWeek =
+                        listOf("월", "화", "수", "목", "금", "토", "일")[localDate.dayOfWeek.ordinal]
+                    val isSelected = selectedDate == dayPlan.date
+                    Box(
+                        modifier = Modifier
+                            .width(86.dp)
+                            .height(36.dp)
+                            .background(
+                                color = if (isSelected) Variables.Blue700 else Color(0xFFF4F4F5),
+                                shape = RoundedCornerShape(5.dp)
+                            )
+                            .clickable { viewModel.setSelectedDate(dayPlan.date) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "${localDate.dayOfMonth}일 ($dayOfWeek)",
+                            style = TextStyle(
+                                fontSize = 15.sp,
+                                fontFamily = FontFamily(Font(R.font.roboto)),
+                                fontWeight = FontWeight.Medium,
+                                color = if (isSelected) Color.White else Variables.Grayscale300
+                            )
+                        )
+                    }
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(24.dp))
+            
+            // 여행지 목록
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f) // 남은 공간을 차지하도록 weight 추가
+            ) {
+                dayPlans.find { it.date == selectedDate }?.let { dayPlan ->
+                    items(dayPlan.places) { place ->
+                        Column(modifier = Modifier.padding(bottom = 12.dp)) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(60.dp)
+                                    .shadow(
+                                        elevation = 4.dp,
+                                        shape = RoundedCornerShape(10.dp),
+                                        ambientColor = Color(0x40A7A7A7),
+                                        spotColor = Color(0x40A7A7A7)
+                                    )
+                                    .background(
+                                        Color.White,
+                                        shape = RoundedCornerShape(10.dp)
+                                    ),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                // "메뉴" 아이콘 대신 더미 Box 또는 다른 아이콘 사용
+                                Icon(
+                                    painter = painterResource(id = R.drawable.ic_menu),
+                                    contentDescription = "메뉴",
+                                    tint = Color.Black,
+                                    modifier = Modifier
+                                        .padding(start = 16.dp)
+                                        .size(18.dp)
+                                )
+                                Text(
+                                    text = place.name,
+                                    style = TextStyle(
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        fontFamily = FontFamily(Font(R.font.roboto)),
+                                        color = Color(0xFF1C1917)
+                                    ),
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(start = 16.dp)
+                                )
+                                
+                                val chargerIconId = if (expandedPlaceId == place.id) {
+                                    R.drawable.ic_charger_on
+                                } else {
+                                    R.drawable.ic_charger_off
+                                }
+                                
+                                Icon(
+                                    painter = painterResource(id = chargerIconId),
+                                    contentDescription = "충전 현황",
+                                    tint = if (expandedPlaceId == place.id) Color(0xFF000000) else Color(0xFF9D9D9D),
+                                    modifier = Modifier
+                                        .padding(end = 12.dp)
+                                        .size(20.dp)
+                                        .clickable {
+                                            expandedPlaceId =
+                                                if (expandedPlaceId == place.id) null else place.id
+                                        }
+                                )
+                            }
+                            
+                            // 충전소 목록 (EditPlanScreen과 동일)
+                            if (expandedPlaceId == place.id && !place.chargers.isNullOrEmpty()) {
+                                Column(
+                                    modifier = Modifier
+                                        .padding(start = 8.dp, end = 0.dp)
+                                        .offset(y = (-4).dp)
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .shadow(
+                                                elevation = 4.dp,
+                                                spotColor = Color(0x40A7A7A7),
+                                                ambientColor = Color(0x40A7A7A7),
+                                                shape = RoundedCornerShape(
+                                                    bottomStart = 10.dp,
+                                                    bottomEnd = 10.dp
+                                                )
+                                            )
+                                            .background(
+                                                color = Color(0xFFFFFFFF),
+                                                shape = RoundedCornerShape(
+                                                    bottomStart = 10.dp,
+                                                    bottomEnd = 10.dp
+                                                )
+                                            )
+                                            .padding(
+                                                vertical = 12.dp,
+                                                horizontal = 16.dp
+                                            )
+                                    ) {
+                                        Column {
+                                            place.chargers!!.forEachIndexed { index, charger ->
+                                                Row(
+                                                    modifier = Modifier.fillMaxWidth(),
+                                                    verticalAlignment = Alignment.CenterVertically
+                                                ) {
+                                                    Text(
+                                                        text = charger.name,
+                                                        style = TextStyle(
+                                                            fontSize = 14.sp,
+                                                            fontFamily = FontFamily(
+                                                                Font(R.font.roboto)
+                                                            ),
+                                                            fontWeight = FontWeight(400),
+                                                            color = Color(0xFF000000),
+                                                        )
+                                                    )
+                                                }
+                                                
+                                                if (index < place.chargers.size - 1) {
+                                                    Spacer(modifier = Modifier.height(8.dp))
+                                                    Box(
+                                                        modifier = Modifier
+                                                            .fillMaxWidth()
+                                                            .height(0.5.dp)
+                                                            .background(Color(0xFFDBDBDB))
+                                                    )
+                                                    Spacer(modifier = Modifier.height(8.dp))
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해 주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feature/add-planlist` → `develop`

### 변경 사항

- **플랜 조회 기능 추가 및 라우팅 개선**:
    - `PlanListScreen`에서 플랜 아이템 클릭 시, 메뉴 버튼 외의 영역을 클릭하면 `ViewPlanScreen`으로 이동하도록 기능을 추가했습니다.
    - `PlanItem` 컴포넌트의 클릭 가능 영역을 분리하여 `ViewPlanScreen`과 `EditPlanScreen`으로의 라우팅을 명확하게 구분했습니다.
    - 플랜 상세 정보를 보여주는 `ViewPlanScreen`을 새로 추가했습니다.
    - 기존 `PlanItem` 컴포넌트의 클릭 리스너를 분리하는 과정에서 `PlanListScreen`, `PlanListForDate` 컴포넌트의 콜백 구조를 리팩토링했습니다.

### 테스트 결과

- 플랜 목록에서 각 아이템 클릭 시 `ViewPlanScreen`으로 정상 이동하는 것을 확인했습니다.
- `ViewPlanScreen`에서 날짜 탭 클릭 시 해당 날짜의 여행지가 올바르게 표시되는 것을 확인했습니다.
- '더보기' 메뉴를 통한 편집 기능이 `EditPlanScreen`으로 정상 연결되는 것을 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 계획 상세 보기 화면 추가(읽기 전용).
  * 계획 목록에서 보기/편집 동작을 분리하고 전용 보기 경로를 추가.

* UI/UX
  * 편집 화면을 장소 중심 카드형 UI로 개편하고 충전소 목록 접기/펼치기 지원.
  * 계획 목록 아이템의 본문을 누르면 상세 보기로 이동.
  * “여행지 추가하기” 항목 추가.
  * 플래너 기본 배경을 밝은 회색으로 변경.

* 탐색
  * 상세 보기로의 전용 라우팅 및 뒤로가기 지원.
  * 일자 선택과 초기 선택 동작을 개선하여 일정 탐색을 더 자연스럽게 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->